### PR TITLE
Constructor function with the same name of the class is deprecated

### DIFF
--- a/sharedaddy/sharing-service.php
+++ b/sharedaddy/sharing-service.php
@@ -357,7 +357,7 @@ class Sharing_Service_Total {
 	var $service	= '';
 	var $total 		= 0;
 
-	public function Sharing_Service_Total( $id, $total ) {
+	public function __construct( $id, $total ) {
 		$services 		= new Sharing_Service();
 		$this->id 		= esc_html( $id );
 		$this->service 	= $services->get_service( $id );
@@ -379,7 +379,7 @@ class Sharing_Post_Total {
 	var $title 	= '';
 	var $url	= '';
 
-	public function Sharing_Post_Total( $id, $total ) {
+	public function __construct( $id, $total ) {
 		$this->id 		= (int) $id;
 		$this->total 	= (int) $total;
 		$this->title	= get_the_title( $this->id );


### PR DESCRIPTION
Constructor function with the same name of the class is deprecated in new versions of PHP and causes some errors
